### PR TITLE
Update .spec file for non-root compilation and more standard layout

### DIFF
--- a/authbind/authbind-2.1.1-install.patch
+++ b/authbind/authbind-2.1.1-install.patch
@@ -1,0 +1,49 @@
+--- Makefile.git	2015-04-18 14:20:42.387382005 -0400
++++ Makefile	2015-04-18 14:24:37.854677346 -0400
+@@ -29,9 +29,9 @@
+ 
+ etc_dir=/etc/authbind
+ 
+-INSTALL_FILE	?= install -o root -g root -m 644 
+-INSTALL_PROGRAM ?= install -o root -g root -m 755 -s
+-INSTALL_DIR	?= install -o root -g root -m 755 -d
++INSTALL_FILE	?= install -m 644 
++INSTALL_PROGRAM ?= install -m 755 -s
++INSTALL_DIR	?= install -m 755 -d
+ STRIP		?= strip
+ 
+ OPTIMISE=	-O2
+@@ -59,19 +59,22 @@
+ all:			$(TARGETS)
+ 
+ install:		$(TARGETS)
+-		$(INSTALL_DIR) $(lib_dir) $(man1_dir) $(man8_dir)
+-		$(INSTALL_PROGRAM) $(BINTARGETS) $(bin_dir)/.
+-		$(INSTALL_FILE) $(LIBTARGET) $(lib_dir)/.
+-		$(STRIP) --strip-unneeded $(lib_dir)/$(LIBTARGET)
+-		ln -sf $(LIBTARGET) $(lib_dir)/$(LIBCANON)
+-		$(INSTALL_PROGRAM) $(HELPER) $(libexec_dir)/.
+-		chmod u+s $(libexec_dir)/$(HELPER)
+-		$(INSTALL_DIR) $(etc_dir) \
+-			$(etc_dir)/byport $(etc_dir)/byaddr $(etc_dir)/byuid
++		$(INSTALL_DIR) $(DESTDIR)$(lib_dir)
++		$(INSTALL_DIR) $(DESTDIR)$(man1_dir)
++		$(INSTALL_DIR) $(DESTDIR)$(man8_dir)
++		$(INSTALL_PROGRAM) $(BINTARGETS) $(DESTDIR)$(bin_dir)/.
++		$(INSTALL_FILE) $(LIBTARGET) $(DESTDIR)$(lib_dir)/.
++		$(STRIP) --strip-unneeded $(DESTDIR)$(lib_dir)/$(LIBTARGET)
++		ln -sf $(LIBTARGET) $(DESTDIR)$(lib_dir)/$(LIBCANON)
++		$(INSTALL_PROGRAM) $(HELPER) $(DESTDIR)$(libexec_dir)/.
++		chmod u+s $(DESTDIR)$(libexec_dir)/$(HELPER)
++		$(INSTALL_DIR) $(DESTDIR)$(etc_dir) \
++		$(INSTALL_DIR) $(DESTDIR)$(etc_dir)/byaddr
++		$(INSTALL_DIR) $(DESTDIR)$(etc_dir)/byuid
+ 
+ install_man:		$(MANPAGES_1) $(MANPAGES_8)
+-		$(INSTALL_FILE) $(MANPAGES_1) $(man1_dir)/.
+-		$(INSTALL_FILE) $(MANPAGES_8) $(man8_dir)/.
++		$(INSTALL_FILE) $(MANPAGES_1) $(DESTDIR)$(man1_dir)/.
++		$(INSTALL_FILE) $(MANPAGES_8) $(DESTDIR)$(man8_dir)/.
+ 
+ libauthbind.o:		libauthbind.c authbind.h
+ 		$(CC) -D_REENTRANT $(CFLAGS) $(CPPFLAGS) -c -o $@ -fPIC $<

--- a/authbind/authbind.spec
+++ b/authbind/authbind.spec
@@ -1,0 +1,66 @@
+%define name		authbind
+%define release		0.1
+%define version 	2.1.1
+%define buildroot %{_topdir}/%{name}-%{version}-root
+
+BuildRoot:	%{buildroot}
+Summary:		Allow non-root users to open restricted ports
+License: 		GPLv2
+Name: 			%{name}
+Version: 		%{version}
+Release:		%{release}
+# Built up from git repo
+Source: 		%{name}-%{version}.tar.gz
+PAtch:			authbind-2.1.1-install.patch
+Group: 			Development/Tools
+
+%description
+Authbind allows the system administrator to permit specific users and groups access to bind to TCP and UDP ports below 1024
+
+%prep
+%setup -q 
+# Clean up installation to use DESTDIR and not install as root
+%patch -b .install
+# Set prefix to use rpmmacro
+sed -i.prefix 's|/usr/local|%{_prefix}|g' Makefile 
+# Set libdir to use rpmmacro, not hardcoded /usr/local
+sed -i.libdir 's|$(prefix)/lib/|$(prefix)/%{_lib}/|g' Makefile 
+# Set etc_dir to use rpmmacro, not hardcoded /etc/authbind
+sed -i.etcdirr 's|/etc/authbind/|%{_sysconfdir}/authbind|g' Makefile 
+
+%build
+make
+
+%install
+rm -rf ${RPM_BUILD_ROOT}
+mkdir -p $RPM_BUILD_ROOT%{_bindir}
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/authbind/byport
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/authbind/byaddr
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/authbind/byuid
+make install DESTDIR=$RPM_BUILD_ROOT
+make install_man DESTDIR=$RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root)
+%attr(4755,root,root) %{_bindir}/authbind
+%attr(4755,root,root) %{_prefix}/%{_lib}/authbind/helper
+%{_prefix}/%{_lib}/authbind/libauthbind.so.1
+%{_prefix}/%{_lib}/authbind/libauthbind.so.1.0
+
+%dir %{_sysconfdir}/authbind/byport
+%dir %{_sysconfdir}/authbind/byaddr
+%dir %{_sysconfdir}/authbind/byuid
+
+%doc %attr(0444,root,root) %{_mandir}/man1/authbind.1*
+%doc %attr(0444,root,root) %{_mandir}/man8/authbind-helper.8*
+
+%changelog
+* Sat Apr 18 2015 Nico Kadel-Garcia <nkadel@gmail.com>
+- Import from https://tootedom/authbind-centos-rpm configs
+- Patch Makefile to not use 'install -o root -g root'
+- Patch Makefile to use 'DESTDIR',
+- Tweak Makefile in setup to use _prefix, _lib, and _sysconfdir values,
+  avoids hardcoded /usr/local/, /usr/lib, and /etc
+- Use .1* and .8* for man files, because of .gz autocompression
+- Set byport, byaddr, and byuid as directories only
+  


### PR DESCRIPTION
From %Changelog in .spec file
- Patch Makefile to not use 'install -o root -g root'
- Patch Makefile to use 'DESTDIR',
- Tweak Makefile in setup to use _prefix, _lib, and _sysconfdir values,
  avoids hardcoded /usr/local/, /usr/lib, and /etc
- Use .1\* and .8\* for man files, because of .gz autocompression
- Set byport, byaddr, and byuid as directories only
